### PR TITLE
feat: testimonial collection pipeline

### DIFF
--- a/apps/web/content/posts/why-i-will-hopefully-always-be-a-coder.mdx
+++ b/apps/web/content/posts/why-i-will-hopefully-always-be-a-coder.mdx
@@ -1,0 +1,62 @@
+---
+title: "Why I Will (Hopefully) Alway Be A Coder"
+date: "2026-02-25"
+description: >
+  When I started coding as a teenager, I couldn't care less about
+  making a career in the field. After 17 years of contracting,
+  I wonder where my path will lead me.
+tags: ["career", "leadership", "teamwork", "software-engineering"]
+---
+
+# "Selbst und Ständig"
+
+In Germany, self-employed translates to "Selbstständig" which basically means you
+stand on your own. This has of course many benefits and responsibilities attached
+to it, one being, unless you hire a business coach, nobody will tell you how to advance
+your career.
+
+That doesn't sound like a problem if you like what you do and on top of it
+you make a good living, but sooner or later you arrive at a point, asking yourself:
+"Should I promote myself? Where is my career going exactly?"
+
+# Like the bees and the flowers
+
+I took the risk of self-employment not because it was a way for me to make a lot of money
+or to build an empire but simply to be my own boss and do what I love: build software.
+
+Maybe I'm naive or not ambitious enough but I thought continuously improving myself,
+learning at every possible occasion and sharing what I've learned with my clients would
+be enough.
+
+# Being on the front(end)
+
+When I started my career, I was doing full-stack work with the LAMP stack,
+as it was the most accessible way of bringing websites to life, but in 2014,
+while building my first "really big application" and implementing a calendar
+first in angular (which was a desaster because of the dirty checking issues AngularJS had)
+I tried this new thing from facebook called React...
+
+Since then I focused on frontends because I saw the potential of constant evolution
+versus the rather standardized way of how backends work.
+
+This has led me to join many react projects since then, learning a lot about the technology
+but also about how different processes and this "agile" everyone talks about.
+
+# Consulting in the trenches
+
+Here is my problem: You probably shouldn't listen to an consultant with the title
+"Frontend Developer", makes sense, in the business world, we have certificates and titles
+that show how experienced you are and what someone who can't really judge your skills themselves
+can expect from you. Which leads me to my initial statement: I should probably promote myself.
+
+Fixing problem from the bottom up gets harder with the levels of hierarchies and while
+most companies have executives that understand the necessity of agile principles like
+self-organizing teams, its hard to keep that importance when you pass the instructions down
+a line of managers where every manager has a dozen other, more pressing things on their plate.
+
+# No compromise
+
+I want to be a good leader and try my best to be involved with my teams, which only
+works when I'm working with them. I can't imagine how to lead when I'm mostly in meetings,
+thats why I always rejected the idea of changing into a role where my job would disconnect
+me from the people that build products.

--- a/apps/web/src/app/admin/testimonials/invitations/invitations-list.tsx
+++ b/apps/web/src/app/admin/testimonials/invitations/invitations-list.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface Invitation {
+  id: string;
+  recipient_name: string;
+  recipient_role: string;
+  engagement_context: string;
+  token: string;
+  status: string;
+  created_at: string;
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  pending: 'bg-yellow-100 text-yellow-800',
+  submitted: 'bg-blue-100 text-blue-800',
+  approved: 'bg-green-100 text-green-800',
+  declined: 'bg-red-100 text-red-800',
+};
+
+export const InvitationsList: React.FC<{ invitations: Invitation[] }> = ({ invitations }) => {
+  const [copiedToken, setCopiedToken] = useState<string | null>(null);
+
+  const copyLink = async (token: string) => {
+    const baseUrl = window.location.origin;
+    await navigator.clipboard.writeText(`${baseUrl}/references/${token}`);
+    setCopiedToken(token);
+    setTimeout(() => setCopiedToken(null), 2000);
+  };
+
+  if (invitations.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-12 text-center text-muted-foreground">
+        No invitations yet.{' '}
+        <a href="/admin/testimonials/invitations/new" className="text-accent hover:underline">
+          Create the first one.
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-sm">
+        <thead className="border-b border-border bg-muted">
+          <tr>
+            <th className="px-4 py-3 text-left font-medium text-foreground">Recipient</th>
+            <th className="px-4 py-3 text-left font-medium text-foreground">Role</th>
+            <th className="px-4 py-3 text-left font-medium text-foreground">Engagement</th>
+            <th className="px-4 py-3 text-left font-medium text-foreground">Date Sent</th>
+            <th className="px-4 py-3 text-left font-medium text-foreground">Status</th>
+            <th className="px-4 py-3 text-left font-medium text-foreground">Link</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border bg-background">
+          {invitations.map((inv) => (
+            <tr key={inv.id} className="transition-colors hover:bg-muted/50">
+              <td className="px-4 py-3 font-medium text-foreground">{inv.recipient_name}</td>
+              <td className="px-4 py-3 capitalize text-muted-foreground">{inv.recipient_role}</td>
+              <td className="max-w-xs px-4 py-3 text-muted-foreground">
+                <span className="line-clamp-2">{inv.engagement_context}</span>
+              </td>
+              <td className="px-4 py-3 text-muted-foreground">
+                {new Date(inv.created_at).toLocaleDateString('de-DE')}
+              </td>
+              <td className="px-4 py-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${STATUS_BADGE[inv.status] ?? 'bg-gray-100 text-gray-800'}`}
+                >
+                  {inv.status}
+                </span>
+              </td>
+              <td className="px-4 py-3">
+                <button
+                  type="button"
+                  onClick={() => copyLink(inv.token)}
+                  className="rounded-md border border-border px-2 py-1 text-xs text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  {copiedToken === inv.token ? 'Copied!' : 'Copy Link'}
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/apps/web/src/app/admin/testimonials/invitations/new/new-invitation-form.tsx
+++ b/apps/web/src/app/admin/testimonials/invitations/new/new-invitation-form.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+import { FormField } from '@/components/ui/form-field';
+
+interface InvitationResult {
+  invitation: {
+    id: string;
+    recipient_name: string;
+    recipient_role: string;
+    engagement_context: string;
+    token: string;
+    status: string;
+  };
+  link: string;
+}
+
+export const NewInvitationForm: React.FC = () => {
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<InvitationResult | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setIsPending(true);
+
+    const form = e.currentTarget;
+    const data = new FormData(form);
+
+    try {
+      const response = await fetch('/api/testimonials/invitations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          recipientName: data.get('recipientName'),
+          recipientRole: data.get('recipientRole'),
+          engagementContext: data.get('engagementContext'),
+        }),
+      });
+
+      if (!response.ok) {
+        const json = await response.json() as { error?: string };
+        setError(json.error ?? 'Failed to create invitation');
+        return;
+      }
+
+      const json = await response.json() as InvitationResult;
+      setResult(json);
+      form.reset();
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!result?.link) return;
+    await navigator.clipboard.writeText(result.link);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <FormField label="Recipient Name" htmlFor="recipientName" required>
+            <Input
+              id="recipientName"
+              name="recipientName"
+              type="text"
+              placeholder="Jane Smith"
+              required
+              disabled={isPending}
+            />
+          </FormField>
+
+          <FormField label="Role / Relationship" htmlFor="recipientRole" required>
+            <Select id="recipientRole" name="recipientRole" required disabled={isPending}>
+              <option value="">Select a role</option>
+              <option value="client">Client</option>
+              <option value="manager">Manager</option>
+              <option value="peer">Peer / Collaborator</option>
+            </Select>
+          </FormField>
+
+          <FormField label="Engagement Context" htmlFor="engagementContext" required>
+            <Textarea
+              id="engagementContext"
+              name="engagementContext"
+              rows={4}
+              placeholder="Describe the project or engagement (e.g. 'React migration at Acme Corp, Q3 2024')"
+              required
+              disabled={isPending}
+            />
+          </FormField>
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+
+          <Button type="submit" variant="primary" disabled={isPending}>
+            {isPending ? 'Creating...' : 'Generate Invitation Link'}
+          </Button>
+        </form>
+      </Card>
+
+      {result && (
+        <Card className="border-accent">
+          <p className="mb-2 text-sm font-medium text-foreground">
+            Invitation created for <strong>{result.invitation.recipient_name}</strong>. Copy the link below and send it manually:
+          </p>
+          <div className="flex items-center gap-3 rounded-md border border-border bg-muted p-3">
+            <code className="flex-1 break-all text-sm text-foreground">{result.link}</code>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="shrink-0 rounded-md border border-border bg-background px-3 py-1 text-xs text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/app/admin/testimonials/invitations/new/page.tsx
+++ b/apps/web/src/app/admin/testimonials/invitations/new/page.tsx
@@ -1,0 +1,38 @@
+import { auth } from 'auth';
+import { redirect } from 'next/navigation';
+import { Container } from '@/components/ui/container';
+import { Heading } from '@/components/ui/heading';
+import { Button } from '@/components/ui/button';
+import { NewInvitationForm } from './new-invitation-form';
+
+const NewInvitationPage = async () => {
+  const session = await auth();
+  if (!session) {
+    redirect('/api/auth/signin?callbackUrl=/admin/testimonials/invitations/new');
+  }
+
+  return (
+    <main className="bg-background py-10">
+      <Container className="px-6">
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <Heading as="h1" variant="display" className="mb-2 text-4xl text-foreground">
+              New Testimonial Invitation
+            </Heading>
+            <p className="text-muted-foreground">
+              Generate a personalized, token-based invitation link to send manually.
+            </p>
+          </div>
+          <Button href="/admin/testimonials/invitations" variant="secondary">
+            Back to Invitations
+          </Button>
+        </div>
+        <div className="max-w-2xl">
+          <NewInvitationForm />
+        </div>
+      </Container>
+    </main>
+  );
+};
+
+export default NewInvitationPage;

--- a/apps/web/src/app/admin/testimonials/invitations/page.tsx
+++ b/apps/web/src/app/admin/testimonials/invitations/page.tsx
@@ -1,0 +1,64 @@
+import { auth } from 'auth';
+import { redirect } from 'next/navigation';
+import { getPool } from '@/lib/db';
+import { Container } from '@/components/ui/container';
+import { Heading } from '@/components/ui/heading';
+import { Button } from '@/components/ui/button';
+import { InvitationsList } from './invitations-list';
+
+interface Invitation {
+  id: string;
+  recipient_name: string;
+  recipient_role: string;
+  engagement_context: string;
+  token: string;
+  status: string;
+  created_at: string;
+}
+
+const InvitationsPage = async () => {
+  const session = await auth();
+  if (!session) {
+    redirect('/api/auth/signin?callbackUrl=/admin/testimonials/invitations');
+  }
+
+  let invitations: Invitation[] = [];
+
+  if (process.env.DATABASE_URL) {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `SELECT id, recipient_name, recipient_role, engagement_context, token, status, created_at
+         FROM testimonial_invitations
+         ORDER BY created_at DESC`
+      );
+      invitations = result.rows as Invitation[];
+    } finally {
+      client.release();
+    }
+  }
+
+  return (
+    <main className="bg-background py-10">
+      <Container className="px-6">
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <Heading as="h1" variant="display" className="mb-2 text-4xl text-foreground">
+              Testimonial Invitations
+            </Heading>
+            <p className="text-muted-foreground">
+              Track who has been invited, their status, and resend links.
+            </p>
+          </div>
+          <Button href="/admin/testimonials/invitations/new" variant="primary">
+            New Invitation
+          </Button>
+        </div>
+        <InvitationsList invitations={invitations} />
+      </Container>
+    </main>
+  );
+};
+
+export default InvitationsPage;

--- a/apps/web/src/app/admin/testimonials/moderation/moderation-list.tsx
+++ b/apps/web/src/app/admin/testimonials/moderation/moderation-list.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useState } from 'react';
+
+type ModerateAction = 'approve' | 'keep_private' | 'decline';
+
+interface Submission {
+  id: string;
+  token: string;
+  recipient_name: string;
+  recipient_role: string;
+  engagement_context: string;
+  answers: Record<string, string>;
+  submitted_at: string;
+  public_with_name: boolean;
+  public_anonymous: boolean;
+}
+
+const QUESTION_LABELS: Record<string, string> = {
+  q1: 'In what context did we work together?',
+  q2: 'What specific challenge or problem were we working on?',
+  q3: 'What was the outcome or result of the work?',
+  q4: 'How would you describe the collaboration and communication?',
+  q5: 'Would you recommend this consultant for this type of work, and if so, to whom?',
+  q6: 'Anything else you would like to add?',
+};
+
+export const ModerationList: React.FC<{ submissions: Submission[] }> = ({ submissions }) => {
+  const [statuses, setStatuses] = useState<Record<string, string>>({});
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<Record<string, string>>({});
+
+  const handleAction = async (token: string, action: ModerateAction) => {
+    setPending((p) => ({ ...p, [token]: true }));
+    setError((e) => ({ ...e, [token]: '' }));
+
+    try {
+      const response = await fetch(`/api/testimonials/${token}/moderate`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      });
+
+      if (!response.ok) {
+        const json = await response.json() as { error?: string };
+        setError((e) => ({ ...e, [token]: json.error ?? 'Action failed' }));
+        return;
+      }
+
+      const actionLabel = action === 'approve' ? 'approved' : action === 'decline' ? 'declined' : 'kept private';
+      setStatuses((s) => ({ ...s, [token]: actionLabel }));
+    } catch {
+      setError((e) => ({ ...e, [token]: 'Network error. Please try again.' }));
+    } finally {
+      setPending((p) => ({ ...p, [token]: false }));
+    }
+  };
+
+  if (submissions.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-12 text-center text-muted-foreground">
+        No submitted testimonials awaiting moderation.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {submissions.map((sub) => (
+        <div key={sub.id} className="rounded-lg border border-border bg-card p-6">
+          <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="font-semibold text-foreground">{sub.recipient_name}</p>
+              <p className="text-sm capitalize text-muted-foreground">{sub.recipient_role}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{sub.engagement_context}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Submitted: {new Date(sub.submitted_at).toLocaleDateString('de-DE')}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Consent:{' '}
+                {sub.public_with_name
+                  ? 'Public with name'
+                  : sub.public_anonymous
+                  ? 'Public anonymous'
+                  : 'Private only'}
+              </p>
+            </div>
+
+            {statuses[sub.token] ? (
+              <span className="rounded-full bg-green-100 px-3 py-1 text-sm font-medium capitalize text-green-800">
+                {statuses[sub.token]}
+              </span>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  disabled={pending[sub.token]}
+                  onClick={() => handleAction(sub.token, 'approve')}
+                  className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  disabled={pending[sub.token]}
+                  onClick={() => handleAction(sub.token, 'keep_private')}
+                  className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-50"
+                >
+                  Keep Private
+                </button>
+                <button
+                  type="button"
+                  disabled={pending[sub.token]}
+                  onClick={() => handleAction(sub.token, 'decline')}
+                  className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+                >
+                  Decline
+                </button>
+              </div>
+            )}
+          </div>
+
+          {error[sub.token] && (
+            <p className="mb-3 text-sm text-red-500">{error[sub.token]}</p>
+          )}
+
+          <div className="space-y-3">
+            {Object.entries(sub.answers).map(([key, value]) => (
+              value && (
+                <div key={key}>
+                  <p className="text-xs font-medium text-muted-foreground">
+                    {QUESTION_LABELS[key] ?? key}
+                  </p>
+                  <p className="mt-0.5 text-sm text-foreground">{value}</p>
+                </div>
+              )
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/app/admin/testimonials/moderation/page.tsx
+++ b/apps/web/src/app/admin/testimonials/moderation/page.tsx
@@ -1,0 +1,78 @@
+import { auth } from 'auth';
+import { redirect } from 'next/navigation';
+import { getPool } from '@/lib/db';
+import { Container } from '@/components/ui/container';
+import { Heading } from '@/components/ui/heading';
+import { Button } from '@/components/ui/button';
+import { ModerationList } from './moderation-list';
+
+interface Submission {
+  id: string;
+  token: string;
+  recipient_name: string;
+  recipient_role: string;
+  engagement_context: string;
+  answers: Record<string, string>;
+  submitted_at: string;
+  public_with_name: boolean;
+  public_anonymous: boolean;
+}
+
+const ModerationPage = async () => {
+  const session = await auth();
+  if (!session) {
+    redirect('/api/auth/signin?callbackUrl=/admin/testimonials/moderation');
+  }
+
+  let submissions: Submission[] = [];
+
+  if (process.env.DATABASE_URL) {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `SELECT
+           i.id,
+           i.token,
+           i.recipient_name,
+           i.recipient_role,
+           i.engagement_context,
+           r.answers,
+           r.submitted_at,
+           c.public_with_name,
+           c.public_anonymous
+         FROM testimonial_invitations i
+         INNER JOIN testimonial_responses r ON r.invitation_id = i.id
+         INNER JOIN testimonial_consent c ON c.invitation_id = i.id
+         WHERE i.status = 'submitted'
+         ORDER BY r.submitted_at DESC`
+      );
+      submissions = result.rows as Submission[];
+    } finally {
+      client.release();
+    }
+  }
+
+  return (
+    <main className="bg-background py-10">
+      <Container className="px-6">
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <Heading as="h1" variant="display" className="mb-2 text-4xl text-foreground">
+              Testimonial Moderation
+            </Heading>
+            <p className="text-muted-foreground">
+              Review submitted responses and decide what to publish.
+            </p>
+          </div>
+          <Button href="/admin/testimonials/invitations" variant="secondary">
+            View Invitations
+          </Button>
+        </div>
+        <ModerationList submissions={submissions} />
+      </Container>
+    </main>
+  );
+};
+
+export default ModerationPage;

--- a/apps/web/src/app/api/testimonials/[token]/moderate/route.ts
+++ b/apps/web/src/app/api/testimonials/[token]/moderate/route.ts
@@ -1,0 +1,62 @@
+import { auth } from 'auth';
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db';
+
+type ModerateAction = 'approve' | 'keep_private' | 'decline';
+
+interface ModerateBody {
+  action?: ModerateAction;
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> }
+): Promise<NextResponse> {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { token } = await params;
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  const body = await request.json() as ModerateBody;
+  const { action } = body;
+
+  const allowedActions: ModerateAction[] = ['approve', 'keep_private', 'decline'];
+  if (!action || !allowedActions.includes(action)) {
+    return NextResponse.json(
+      { error: `action must be one of: ${allowedActions.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  const statusMap: Record<ModerateAction, string> = {
+    approve: 'approved',
+    keep_private: 'submitted',
+    decline: 'declined',
+  };
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `UPDATE testimonial_invitations
+       SET status = $1, updated_at = now()
+       WHERE token = $2
+       RETURNING id, status`,
+      [statusMap[action], token]
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ invitation: result.rows[0] });
+  } finally {
+    client.release();
+  }
+}

--- a/apps/web/src/app/api/testimonials/[token]/route.ts
+++ b/apps/web/src/app/api/testimonials/[token]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> }
+): Promise<NextResponse> {
+  const { token } = await params;
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT id, recipient_name, recipient_role, engagement_context, token, status, created_at
+       FROM testimonial_invitations
+       WHERE token = $1`,
+      [token]
+    );
+
+    if (result.rows.length === 0) {
+      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ invitation: result.rows[0] });
+  } finally {
+    client.release();
+  }
+}

--- a/apps/web/src/app/api/testimonials/[token]/submit/route.ts
+++ b/apps/web/src/app/api/testimonials/[token]/submit/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db';
+import { sendEmail } from '@/lib/email';
+
+interface SubmitBody {
+  answers?: Record<string, string>;
+  consent?: {
+    publicWithName?: boolean;
+    publicAnonymous?: boolean;
+  };
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ token: string }> }
+): Promise<NextResponse> {
+  const { token } = await params;
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  const body = await request.json() as SubmitBody;
+  const { answers = {}, consent = {} } = body;
+
+  const hasSubstantiveAnswer = Object.values(answers).some(
+    (v) => typeof v === 'string' && v.trim().length > 0
+  );
+  if (!hasSubstantiveAnswer) {
+    return NextResponse.json(
+      { error: 'At least one substantive answer is required' },
+      { status: 400 }
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const invResult = await client.query(
+      `SELECT id, recipient_name, engagement_context, status
+       FROM testimonial_invitations
+       WHERE token = $1
+       FOR UPDATE`,
+      [token]
+    );
+
+    if (invResult.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 });
+    }
+
+    const invitation = invResult.rows[0] as {
+      id: string;
+      recipient_name: string;
+      engagement_context: string;
+      status: string;
+    };
+
+    if (invitation.status !== 'pending') {
+      await client.query('ROLLBACK');
+      return NextResponse.json(
+        { error: 'This invitation has already been submitted' },
+        { status: 409 }
+      );
+    }
+
+    await client.query(
+      `INSERT INTO testimonial_responses (invitation_id, answers)
+       VALUES ($1, $2)`,
+      [invitation.id, JSON.stringify(answers)]
+    );
+
+    const publicWithName = Boolean(consent.publicWithName);
+    const publicAnonymous = Boolean(consent.publicAnonymous);
+    const privateOnly = !publicWithName && !publicAnonymous;
+
+    await client.query(
+      `INSERT INTO testimonial_consent (invitation_id, public_with_name, public_anonymous, private_only)
+       VALUES ($1, $2, $3, $4)`,
+      [invitation.id, publicWithName, publicAnonymous, privateOnly]
+    );
+
+    await client.query(
+      `UPDATE testimonial_invitations SET status = 'submitted', updated_at = now() WHERE id = $1`,
+      [invitation.id]
+    );
+
+    await client.query('COMMIT');
+
+    await notifyOwner(invitation.recipient_name, invitation.engagement_context).catch(
+      (err) => console.error('Failed to send testimonial notification email:', err)
+    );
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function notifyOwner(recipientName: string, engagementContext: string): Promise<void> {
+  const notificationEmail = process.env.NOTIFICATION_EMAIL;
+  if (!notificationEmail) return;
+
+  const adminUrl = process.env.NEXTAUTH_URL || process.env.AUTH_URL || 'https://clean.dev';
+
+  await sendEmail({
+    to: notificationEmail,
+    subject: 'New testimonial submission received',
+    html: `
+      <p>A new testimonial has been submitted.</p>
+      <p><strong>Respondent:</strong> ${escapeHtml(recipientName)}</p>
+      <p><strong>Engagement:</strong> ${escapeHtml(engagementContext)}</p>
+      <p><a href="${adminUrl}/admin/testimonials/moderation">Review in admin</a></p>
+    `,
+  });
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/web/src/app/api/testimonials/invitations/route.ts
+++ b/apps/web/src/app/api/testimonials/invitations/route.ts
@@ -1,0 +1,82 @@
+import { auth } from 'auth';
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db';
+import { randomUUID } from 'crypto';
+
+export async function GET(): Promise<NextResponse> {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT id, recipient_name, recipient_role, engagement_context, token, status, created_at, updated_at
+       FROM testimonial_invitations
+       ORDER BY created_at DESC`
+    );
+    return NextResponse.json({ invitations: result.rows });
+  } finally {
+    client.release();
+  }
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  const body = await request.json() as {
+    recipientName?: string;
+    recipientRole?: string;
+    engagementContext?: string;
+  };
+
+  const { recipientName, recipientRole, engagementContext } = body;
+
+  if (!recipientName || !recipientRole || !engagementContext) {
+    return NextResponse.json(
+      { error: 'recipientName, recipientRole, and engagementContext are required' },
+      { status: 400 }
+    );
+  }
+
+  const allowedRoles = ['client', 'manager', 'peer'];
+  if (!allowedRoles.includes(recipientRole)) {
+    return NextResponse.json(
+      { error: `recipientRole must be one of: ${allowedRoles.join(', ')}` },
+      { status: 400 }
+    );
+  }
+
+  const token = randomUUID();
+  const pool = getPool();
+  const dbClient = await pool.connect();
+  try {
+    const result = await dbClient.query(
+      `INSERT INTO testimonial_invitations (recipient_name, recipient_role, engagement_context, token, status)
+       VALUES ($1, $2, $3, $4, 'pending')
+       RETURNING id, recipient_name, recipient_role, engagement_context, token, status, created_at`,
+      [recipientName, recipientRole, engagementContext, token]
+    );
+
+    const invitation = result.rows[0];
+    const baseUrl = process.env.NEXTAUTH_URL || process.env.AUTH_URL || 'https://clean.dev';
+    const link = `${baseUrl}/references/${token}`;
+
+    return NextResponse.json({ invitation, link }, { status: 201 });
+  } finally {
+    dbClient.release();
+  }
+}

--- a/apps/web/src/app/api/testimonials/public/route.ts
+++ b/apps/web/src/app/api/testimonials/public/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db';
+
+export async function GET(): Promise<NextResponse> {
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json({ testimonials: [] });
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      `SELECT
+         i.token,
+         i.recipient_name,
+         i.recipient_role,
+         i.engagement_context,
+         r.answers,
+         r.submitted_at,
+         c.public_with_name,
+         c.public_anonymous
+       FROM testimonial_invitations i
+       INNER JOIN testimonial_responses r ON r.invitation_id = i.id
+       INNER JOIN testimonial_consent c ON c.invitation_id = i.id
+       WHERE i.status = 'approved'
+         AND (c.public_with_name = true OR c.public_anonymous = true)
+       ORDER BY r.submitted_at DESC`
+    );
+    return NextResponse.json({ testimonials: result.rows });
+  } finally {
+    client.release();
+  }
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -76,6 +76,14 @@ const RootLayout = async ({children}: PropsWithChildren) => {
                       {intl.formatMessage({ id: 'nav.blog' })}
                     </Link>
                   </li>
+                  <li>
+                    <Link
+                      className="text-label text-foreground transition-colors hover:text-accent"
+                      href="/references"
+                    >
+                      {intl.formatMessage({ id: 'nav.references' })}
+                    </Link>
+                  </li>
                 </ul>
                 <LanguageSwitcher currentLocale={locale} />
                 {session && <UserMenu session={session} />}

--- a/apps/web/src/app/references/[token]/page.tsx
+++ b/apps/web/src/app/references/[token]/page.tsx
@@ -1,0 +1,96 @@
+import { notFound } from 'next/navigation';
+import { getPool } from '@/lib/db';
+import { Container } from '@/components/ui/container';
+import { Heading } from '@/components/ui/heading';
+import { TestimonialForm } from './testimonial-form';
+import { Card } from '@/components/ui/card';
+
+interface Invitation {
+  id: string;
+  recipient_name: string;
+  recipient_role: string;
+  engagement_context: string;
+  token: string;
+  status: string;
+}
+
+const TestimonialPage = async ({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) => {
+  const { token } = await params;
+
+  if (!process.env.DATABASE_URL) {
+    return (
+      <main className="bg-background py-16">
+        <Container className="px-6">
+          <Card className="max-w-xl text-center">
+            <p className="text-muted-foreground">This feature is not available right now.</p>
+          </Card>
+        </Container>
+      </main>
+    );
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+  let invitation: Invitation | null = null;
+  try {
+    const result = await client.query(
+      `SELECT id, recipient_name, recipient_role, engagement_context, token, status
+       FROM testimonial_invitations
+       WHERE token = $1`,
+      [token]
+    );
+    invitation = result.rows[0] as Invitation | undefined ?? null;
+  } finally {
+    client.release();
+  }
+
+  if (!invitation) {
+    notFound();
+  }
+
+  if (invitation.status === 'submitted' || invitation.status === 'approved' || invitation.status === 'declined') {
+    return (
+      <main className="bg-background py-16">
+        <Container className="px-6">
+          <div className="mx-auto max-w-xl">
+            <Card className="text-center">
+              <div className="py-8">
+                <div className="mb-4 text-4xl">✓</div>
+                <Heading as="h1" variant="display" className="mb-2 text-3xl text-foreground">
+                  Already submitted
+                </Heading>
+                <p className="text-muted-foreground">
+                  This invitation has already been used. Thank you for your feedback.
+                </p>
+              </div>
+            </Card>
+          </div>
+        </Container>
+      </main>
+    );
+  }
+
+  return (
+    <main className="bg-background py-16">
+      <Container className="px-6">
+        <div className="mx-auto max-w-2xl">
+          <div className="mb-10 text-center">
+            <Heading as="h1" variant="display" className="mb-3 text-4xl text-foreground">
+              Share your experience
+            </Heading>
+            <p className="text-lg text-muted-foreground">
+              This questionnaire takes under 5 minutes. No account required.
+            </p>
+          </div>
+          <TestimonialForm invitation={invitation} token={token} />
+        </div>
+      </Container>
+    </main>
+  );
+};
+
+export default TestimonialPage;

--- a/apps/web/src/app/references/[token]/testimonial-form.tsx
+++ b/apps/web/src/app/references/[token]/testimonial-form.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { FormField } from '@/components/ui/form-field';
+
+interface Invitation {
+  recipient_name: string;
+  recipient_role: string;
+  engagement_context: string;
+}
+
+interface TestimonialFormProps {
+  invitation: Invitation;
+  token: string;
+}
+
+const QUESTIONS = [
+  { key: 'q1', label: 'In what context did we work together?' },
+  { key: 'q2', label: 'What specific challenge or problem were we working on?' },
+  { key: 'q3', label: 'What was the outcome or result of the work?' },
+  { key: 'q4', label: 'How would you describe the collaboration and communication?' },
+  { key: 'q5', label: 'Would you recommend this consultant for this type of work, and if so, to whom?' },
+  { key: 'q6', label: 'Anything else you would like to add?' },
+];
+
+export const TestimonialForm: React.FC<TestimonialFormProps> = ({ invitation, token }) => {
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [consent, setConsent] = useState({ publicWithName: false, publicAnonymous: false });
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const hasSubstantiveAnswer = Object.values(answers).some((v) => v.trim().length > 0);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!hasSubstantiveAnswer) {
+      setError('Please fill in at least one answer before submitting.');
+      return;
+    }
+
+    setIsPending(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/testimonials/${token}/submit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answers, consent }),
+      });
+
+      if (response.status === 409) {
+        setSubmitted(true);
+        return;
+      }
+
+      if (!response.ok) {
+        const json = await response.json() as { error?: string };
+        setError(json.error ?? 'Submission failed. Please try again.');
+        return;
+      }
+
+      setSubmitted(true);
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <Card className="text-center">
+        <div className="py-8">
+          <div className="mb-4 text-4xl">✓</div>
+          <h2 className="mb-2 font-serif text-2xl font-bold text-foreground">
+            Thank you, {invitation.recipient_name}.
+          </h2>
+          <p className="text-muted-foreground">
+            Your feedback has been received. It will be reviewed before any public display.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-8">
+      <Card>
+        <h2 className="mb-1 font-serif text-xl font-semibold text-foreground">Your details</h2>
+        <p className="mb-4 text-sm text-muted-foreground">Pre-filled from your invitation — read only.</p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">Name</p>
+            <p className="mt-1 text-foreground">{invitation.recipient_name}</p>
+          </div>
+          <div>
+            <p className="text-xs font-medium text-muted-foreground">Role</p>
+            <p className="mt-1 capitalize text-foreground">{invitation.recipient_role}</p>
+          </div>
+          <div className="sm:col-span-2">
+            <p className="text-xs font-medium text-muted-foreground">Engagement</p>
+            <p className="mt-1 text-foreground">{invitation.engagement_context}</p>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <h2 className="mb-1 font-serif text-xl font-semibold text-foreground">Your feedback</h2>
+        <p className="mb-6 text-sm text-muted-foreground">
+          All fields are optional, but please fill in at least one. Prose answers are much more useful than ratings.
+        </p>
+        <div className="space-y-6">
+          {QUESTIONS.map((q) => (
+            <FormField key={q.key} label={q.label} htmlFor={q.key}>
+              <Textarea
+                id={q.key}
+                rows={3}
+                value={answers[q.key] ?? ''}
+                onChange={(e) => setAnswers((prev) => ({ ...prev, [q.key]: e.target.value }))}
+                disabled={isPending}
+              />
+            </FormField>
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <h2 className="mb-1 font-serif text-xl font-semibold text-foreground">Publishing consent</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Choose how your feedback may be used. If you select neither, your response is stored as a private reference only and will not appear publicly.
+        </p>
+        <div className="space-y-3">
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-4 w-4 rounded border-border accent-accent"
+              checked={consent.publicWithName}
+              onChange={(e) =>
+                setConsent((prev) => ({
+                  ...prev,
+                  publicWithName: e.target.checked,
+                  publicAnonymous: e.target.checked ? false : prev.publicAnonymous,
+                }))
+              }
+              disabled={isPending}
+            />
+            <span className="text-sm text-foreground">
+              I consent to this feedback being published publicly on clean.dev with my name and role.
+            </span>
+          </label>
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-4 w-4 rounded border-border accent-accent"
+              checked={consent.publicAnonymous}
+              onChange={(e) =>
+                setConsent((prev) => ({
+                  ...prev,
+                  publicAnonymous: e.target.checked,
+                  publicWithName: e.target.checked ? false : prev.publicWithName,
+                }))
+              }
+              disabled={isPending}
+            />
+            <span className="text-sm text-foreground">
+              I prefer to remain anonymous — publish feedback without my name.
+            </span>
+          </label>
+        </div>
+      </Card>
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      <Button type="submit" variant="primary" disabled={isPending || !hasSubstantiveAnswer}>
+        {isPending ? 'Submitting...' : 'Submit feedback'}
+      </Button>
+    </form>
+  );
+};

--- a/apps/web/src/app/references/page.tsx
+++ b/apps/web/src/app/references/page.tsx
@@ -1,0 +1,110 @@
+import { getPool } from '@/lib/db';
+import { Container } from '@/components/ui/container';
+import { Heading } from '@/components/ui/heading';
+import { Section } from '@/components/ui/section';
+
+interface TestimonialRow {
+  token: string;
+  recipient_name: string;
+  recipient_role: string;
+  engagement_context: string;
+  answers: Record<string, string>;
+  submitted_at: string;
+  public_with_name: boolean;
+  public_anonymous: boolean;
+}
+
+const QUOTE_KEY_PREFERENCE = ['q3', 'q2', 'q4', 'q5', 'q1', 'q6'];
+
+function pickQuote(answers: Record<string, string>): string {
+  for (const key of QUOTE_KEY_PREFERENCE) {
+    if (answers[key]?.trim()) return answers[key].trim();
+  }
+  return '';
+}
+
+const ReferencesPage = async () => {
+  let testimonials: TestimonialRow[] = [];
+
+  if (process.env.DATABASE_URL) {
+    const pool = getPool();
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `SELECT
+           i.token,
+           i.recipient_name,
+           i.recipient_role,
+           i.engagement_context,
+           r.answers,
+           r.submitted_at,
+           c.public_with_name,
+           c.public_anonymous
+         FROM testimonial_invitations i
+         INNER JOIN testimonial_responses r ON r.invitation_id = i.id
+         INNER JOIN testimonial_consent c ON c.invitation_id = i.id
+         WHERE i.status = 'approved'
+           AND (c.public_with_name = true OR c.public_anonymous = true)
+         ORDER BY r.submitted_at DESC`
+      );
+      testimonials = result.rows as TestimonialRow[];
+    } finally {
+      client.release();
+    }
+  }
+
+  return (
+    <main className="bg-background">
+      <Section className="section-border">
+        <Container className="px-6">
+          <div className="mb-16 max-w-2xl">
+            <Heading as="h1" variant="display" className="mb-4 text-5xl text-foreground">
+              References
+            </Heading>
+            <p className="text-xl leading-relaxed text-muted-foreground">
+              Specific, outcome-oriented feedback from clients, managers, and collaborators I have worked with.
+            </p>
+          </div>
+
+          {testimonials.length === 0 ? (
+            <p className="text-muted-foreground">No published references yet.</p>
+          ) : (
+            <div className="grid gap-8 md:grid-cols-2">
+              {testimonials.map((t) => {
+                const quote = pickQuote(t.answers);
+                if (!quote) return null;
+
+                const displayName = t.public_with_name ? t.recipient_name : 'Anonymous';
+                const period = new Date(t.submitted_at).toLocaleDateString('de-DE', {
+                  month: 'long',
+                  year: 'numeric',
+                });
+
+                return (
+                  <figure
+                    key={t.token}
+                    className="flex flex-col rounded-lg border border-border bg-card p-8"
+                  >
+                    <blockquote className="flex-1">
+                      <p className="font-serif text-lg leading-relaxed text-foreground before:content-['\u201C'] after:content-['\u201D']">
+                        {quote}
+                      </p>
+                    </blockquote>
+                    <figcaption className="mt-6 border-t border-border pt-4">
+                      <p className="font-medium text-foreground">{displayName}</p>
+                      <p className="text-sm capitalize text-muted-foreground">{t.recipient_role}</p>
+                      <p className="text-sm text-muted-foreground">{t.engagement_context}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">{period}</p>
+                    </figcaption>
+                  </figure>
+                );
+              })}
+            </div>
+          )}
+        </Container>
+      </Section>
+    </main>
+  );
+};
+
+export default ReferencesPage;

--- a/apps/web/src/messages/de.json
+++ b/apps/web/src/messages/de.json
@@ -210,5 +210,6 @@
   "pdf.loading": "PDF wird erstellt...",
   "pdf.download": "PDF herunterladen",
   "pdf.loading2": "PDF wird geladen...",
-  "pdf.error": "Fehler beim Laden der PDF: {message}"
+  "pdf.error": "Fehler beim Laden der PDF: {message}",
+  "nav.references": "Referenzen"
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -210,5 +210,6 @@
   "pdf.loading": "Creating PDF...",
   "pdf.download": "Download PDF",
   "pdf.loading2": "Loading PDF...",
-  "pdf.error": "Error loading PDF: {message}"
+  "pdf.error": "Error loading PDF: {message}",
+  "nav.references": "References"
 }

--- a/packages/pm/drizzle/0002_testimonial_tables.sql
+++ b/packages/pm/drizzle/0002_testimonial_tables.sql
@@ -1,0 +1,41 @@
+CREATE TYPE testimonial_status AS ENUM ('pending', 'submitted', 'approved', 'declined');
+--> statement-breakpoint
+CREATE TYPE testimonial_role AS ENUM ('client', 'manager', 'peer');
+--> statement-breakpoint
+CREATE TABLE "testimonial_invitations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"recipient_name" text NOT NULL,
+	"recipient_role" testimonial_role NOT NULL,
+	"engagement_context" text NOT NULL,
+	"token" uuid NOT NULL DEFAULT gen_random_uuid(),
+	"status" testimonial_status NOT NULL DEFAULT 'pending',
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "testimonial_invitations_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "testimonial_invitations_token_idx" ON "testimonial_invitations" ("token");
+--> statement-breakpoint
+CREATE INDEX "testimonial_invitations_status_idx" ON "testimonial_invitations" ("status");
+--> statement-breakpoint
+CREATE TABLE "testimonial_responses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"invitation_id" uuid NOT NULL,
+	"answers" jsonb NOT NULL DEFAULT '{}'::jsonb,
+	"submitted_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "testimonial_responses_invitation_id_unique" UNIQUE("invitation_id")
+);
+--> statement-breakpoint
+ALTER TABLE "testimonial_responses" ADD CONSTRAINT "testimonial_responses_invitation_id_fk" FOREIGN KEY ("invitation_id") REFERENCES "public"."testimonial_invitations"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE TABLE "testimonial_consent" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"invitation_id" uuid NOT NULL,
+	"public_with_name" boolean NOT NULL DEFAULT false,
+	"public_anonymous" boolean NOT NULL DEFAULT false,
+	"private_only" boolean NOT NULL DEFAULT true,
+	"recorded_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "testimonial_consent_invitation_id_unique" UNIQUE("invitation_id")
+);
+--> statement-breakpoint
+ALTER TABLE "testimonial_consent" ADD CONSTRAINT "testimonial_consent_invitation_id_fk" FOREIGN KEY ("invitation_id") REFERENCES "public"."testimonial_invitations"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/pm/drizzle/meta/_journal.json
+++ b/packages/pm/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771138800000,
       "tag": "0001_rename_freelancer_add_payment_terms",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1743358800000,
+      "tag": "0002_testimonial_tables",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Implements the full testimonial collection pipeline from #64 across all 5 work streams in a single branch.

## Changes

### Stream 1 — Database (#65)
- Drizzle migration `0002_testimonial_tables.sql` adding:
  - `testimonial_invitations` — UUID token, status enum, recipient info
  - `testimonial_responses` — JSONB answers, idempotent (unique invitation FK)
  - `testimonial_consent` — immutable public/anonymous/private consent record
- Unique index on token, status index, FK cascade constraints

### Stream 2 — Backend API routes (#66)
- `POST /api/testimonials/invitations` — create invitation (admin)
- `GET /api/testimonials/invitations` — list all invitations (admin)
- `GET /api/testimonials/[token]` — fetch invitation by token (public)
- `POST /api/testimonials/[token]/submit` — submit response + consent (public, transactional, 409 if already submitted)
- `PATCH /api/testimonials/[token]/moderate` — approve/keep_private/decline (admin)
- `GET /api/testimonials/public` — approved public testimonials
- Email notification to `NOTIFICATION_EMAIL` on submission (no response body — privacy hygiene)

### Stream 3 — Admin UI (#67)
- `/admin/testimonials/invitations/new` — invitation creation form, displays copy-link after creation
- `/admin/testimonials/invitations` — dashboard table with status badges and copy-link buttons
- `/admin/testimonials/moderation` — submitted testimonials with Approve / Keep Private / Decline actions

### Stream 4 — Public questionnaire (#68)
- `/references/[token]` — fully public, no auth required
- Pre-filled name and engagement context (read-only)
- 6 guided prose textareas, no rating scales
- Consent checkboxes (public with name / anonymous / private only)
- Idempotency: revisiting a submitted token shows thank-you screen
- At least one substantive answer required before submit is enabled

### Stream 5 — Public testimonials display (#69)
- `/references` — server-rendered list of approved public testimonials
- Shows quote, name or Anonymous, role, engagement, time period
- Empty state handled gracefully
- References link added to main navigation (en + de translations)

## Type check
`pnpm tsc --noEmit` passes with no errors.

Closes #65
Closes #66
Closes #67
Closes #68
Closes #69